### PR TITLE
Hotfix/create customer card

### DIFF
--- a/Omise.Net.NUnit.Test/CardTest.cs
+++ b/Omise.Net.NUnit.Test/CardTest.cs
@@ -30,48 +30,72 @@ namespace Omise.Net.NUnit.Test
             card.ExpirationYear = 2017;
 
             //Stub for internal TokenService call
-            stubResponse("/tokens", "POST", @"{
-								    'object': 'token',
-								    'id': '123',
-								    'livemode': false,
-								    'location': '/tokens/123',
-								    'used': false,
-								    'card': {
-								        'object': 'card',
-								        'livemode': false,
-								        'country': '',
-								        'city': null,
-								        'postal_code': null,
-								        'financing': '',
-								        'last_digits': '4242',
-								        'brand': 'Visa',
-								        'expiration_month': 9,
-								        'expiration_year': 2017,
-								        'fingerprint': '123',
-								        'name': 'TestCard',
-								        'created': '2014-10-02T07:27:30Z'
-								    },
-								    'created': '2014-10-02T07:27:30Z'
-								}
-								");
+            stubResponse("/tokens", "POST", 
+                @"{
+                            'object': 'token',
+                            'id': 'tokn_test_4yw4c9fa79ebj9ajisj',
+                            'livemode': false,
+                            'location': '/tokens/tokn_test_4yw4c9fa79ebj9ajisj',
+                            'used': false,
+                            'card': {
+                                'object': 'card',
+                                'id': 'card_test_122',
+                                'livemode': false,
+                                'country': 'us',
+                                'city': null,
+                                'postal_code': null,
+                                'financing': '',
+                                'last_digits': '1111',
+                                'brand': 'Visa',
+                                'expiration_month': 9,
+                                'expiration_year': 2017,
+                                'fingerprint': '122',
+                                'name': 'Test Card',
+                                'security_code_check': true,
+                                'created': '2014-12-15T08:10:04Z'
+                            },
+                            'created': '2014-12-15T08:10:04Z'
+                        }");
 
-            stubResponse(string.Format("/customers/{0}/cards", customerId), "POST", @"{
-				'object': 'card',
-				'id': '123',
-				'livemode': false,
-				'location': '/customers/123/cards/123',
-				'country': 'Thailand',
-				'city': 'Bangkok',
-				'postal_code': null,
-				'financing': '',
-				'last_digits': '4242',
-				'brand': 'Visa',
-				'expiration_month': 9,
-				'expiration_year': 2017,
-				'fingerprint': '123',
-				'name': 'Test Card',
-				'created': '2014-10-02T06:09:01Z'
-				}");
+            stubResponse(@"{
+                'object': 'customer',
+                'id': 'cust_test_1',
+                'livemode': false,
+                'location': '/customers/cust_test_1',
+                'default_card': 'card_test_122',
+                'email': '',
+                'description': 'Test customer',
+                'created': '2014-12-15T08:10:23Z',
+                'cards': {
+                    'object': 'list',
+                    'from': '1970-01-01T00:00:00+00:00',
+                    'to': '2015-01-30T08:01:21+00:00',
+                    'offset': 0,
+                    'limit': 20,
+                    'total': 1,
+                    'data': [
+                        {
+                            'object': 'card',
+                            'id': 'card_test_122',
+                            'livemode': false,
+                            'location': '/customers/cust_test_1/cards/card_test_122',
+                            'country': 'us',
+                            'city': null,
+                            'postal_code': null,
+                            'financing': '',
+                            'last_digits': '4242',
+                            'brand': 'Visa',
+                            'expiration_month': 9,
+                            'expiration_year': 2017,
+                            'fingerprint': '122',
+                            'name': 'Test Card',
+                            'security_code_check': true,
+                            'created': '2014-12-15T08:10:04Z'
+                        }
+                    ],
+                    'location': '/customers/cust_test_1/cards'
+                }
+            }");
 
             var result = client.CardService.CreateCard(customerId, card);
             Assert.AreEqual("4242", result.LastDigits);
@@ -79,80 +103,150 @@ namespace Omise.Net.NUnit.Test
             Assert.AreEqual(card.ExpirationYear, result.ExpirationYear);
             Assert.AreEqual(card.Name, result.Name);
             Assert.AreEqual(Brand.Visa, result.Brand);
-            Assert.AreEqual("Bangkok", result.City);
-            Assert.AreEqual("Thailand", result.Country);
-            Assert.AreEqual("123", result.Fingerprint);
-            Assert.AreEqual("123", result.Id);
-            Assert.AreEqual(new DateTime(2014, 10, 2, 6, 9, 1), result.CreatedAt);
+            Assert.IsNull(result.City);
+            Assert.AreEqual("us", result.Country);
+            Assert.AreEqual("122", result.Fingerprint);
+            Assert.AreEqual("card_test_122", result.Id);
+            Assert.AreEqual("/customers/cust_test_1/cards/card_test_122", result.Location);
+            Assert.AreEqual(new DateTime(2014, 12, 15, 8, 10, 4), result.CreatedAt);
         }
 
         [Test]
         public void TestCreateCardWithCardToken()
         {
             var card = new CardCreateInfo();
-            card.Name = "Test Card";
-            card.Number = "4242424242424242";
-            card.ExpirationMonth = 9;
-            card.ExpirationYear = 2017;
+            card.Name = "Test new card";
+            card.Number = "4111111111111111";
+            card.ExpirationMonth = 12;
+            card.ExpirationYear = 2019;
 
             var token = new TokenInfo();
             token.Card = card;
 
             stubResponse(@"{
-								    'object': 'token',
-								    'id': '123',
-								    'livemode': false,
-								    'location': '/tokens/123',
-								    'used': false,
-								    'card': {
-								        'object': 'card',
-								        'livemode': false,
-								        'country': '',
-								        'city': null,
-								        'postal_code': null,
-								        'financing': '',
-								        'last_digits': '4242',
-								        'brand': 'Visa',
-								        'expiration_month': 9,
-								        'expiration_year': 2017,
-								        'fingerprint': '123',
-								        'name': 'TestCard',
-								        'created': '2014-10-02T07:27:30Z'
-								    },
-								    'created': '2014-10-02T07:27:30Z'
-								}
-								");
+                            'object': 'token',
+                            'id': 'tokn_test_4yw4c9fa79ebj9ajisj',
+                            'livemode': false,
+                            'location': '/tokens/tokn_test_4yw4c9fa79ebj9ajisj',
+                            'used': false,
+                            'card': {
+                                'object': 'card',
+                                'id': 'card_test_123',
+                                'livemode': false,
+                                'country': 'us',
+                                'city': null,
+                                'postal_code': null,
+                                'financing': '',
+                                'last_digits': '1111',
+                                'brand': 'Visa',
+                                'expiration_month': 12,
+                                'expiration_year': 2019,
+                                'fingerprint': '123',
+                                'name': 'Test new card',
+                                'security_code_check': true,
+                                'created': '2015-01-30T07:58:52Z'
+                            },
+                            'created': '2015-01-30T07:58:52Z'
+                        }");
+
             var resultToken = client.TokenService.CreateToken(token);
 
+            stubResponse("/tokens/" + resultToken.Id, "GET", @"{
+                            'object': 'token',
+                            'id': 'tokn_test_4yw4c9fa79ebj9ajisj',
+                            'livemode': false,
+                            'location': '/tokens/tokn_test_4yw4c9fa79ebj9ajisj',
+                            'used': false,
+                            'card': {
+                                'object': 'card',
+                                'id': 'card_test_123',
+                                'livemode': false,
+                                'country': 'us',
+                                'city': null,
+                                'postal_code': null,
+                                'financing': '',
+                                'last_digits': '1111',
+                                'brand': 'Visa',
+                                'expiration_month': 12,
+                                'expiration_year': 2019,
+                                'fingerprint': '123',
+                                'name': 'Test new card',
+                                'security_code_check': true,
+                                'created': '2015-01-30T07:58:52Z'
+                            },
+                            'created': '2015-01-30T07:58:52Z'
+                        }");
+
             stubResponse(@"{
-				'object': 'card',
-				'id': '123',
-				'livemode': false,
-				'location': '/customers/123/cards/123',
-				'country': 'Thailand',
-				'city': 'Bangkok',
-				'postal_code': null,
-				'financing': '',
-				'last_digits': '4242',
-				'brand': 'Visa',
-				'expiration_month': 9,
-				'expiration_year': 2017,
-				'fingerprint': '123',
-				'name': 'Test Card',
-				'created': '2014-10-02T06:09:01Z'
-				}");
+                'object': 'customer',
+                'id': 'cust_test_1',
+                'livemode': false,
+                'location': '/customers/cust_test_1',
+                'default_card': 'card_test_122',
+                'email': '',
+                'description': 'Test customer',
+                'created': '2014-12-15T08:10:23Z',
+                'cards': {
+                    'object': 'list',
+                    'from': '1970-01-01T00:00:00+00:00',
+                    'to': '2015-01-30T08:01:21+00:00',
+                    'offset': 0,
+                    'limit': 20,
+                    'total': 2,
+                    'data': [
+                        {
+                            'object': 'card',
+                            'id': 'card_test_122',
+                            'livemode': false,
+                            'location': '/customers/cust_test_1/cards/card_test_122',
+                            'country': 'us',
+                            'city': null,
+                            'postal_code': null,
+                            'financing': '',
+                            'last_digits': '4242',
+                            'brand': 'Visa',
+                            'expiration_month': 9,
+                            'expiration_year': 2017,
+                            'fingerprint': '122',
+                            'name': 'Test',
+                            'security_code_check': true,
+                            'created': '2014-12-15T08:10:04Z'
+                        },
+                        {
+                            'object': 'card',
+                            'id': 'card_test_123',
+                            'livemode': false,
+                            'location': '/customers/cust_test_1/cards/card_test_123',
+                            'country': 'us',
+                            'city': null,
+                            'postal_code': null,
+                            'financing': '',
+                            'last_digits': '1111',
+                            'brand': 'Visa',
+                            'expiration_month': 12,
+                            'expiration_year': 2019,
+                            'fingerprint': '123',
+                            'name': 'Test new card',
+                            'security_code_check': true,
+                            'created': '2015-01-30T07:58:52Z'
+                        }
+                    ],
+                    'location': '/customers/cust_test_1/cards'
+                }
+            }");
 
             var result = client.CardService.CreateCard(customerId, resultToken.Id);
-            Assert.AreEqual("4242", result.LastDigits);
+            Assert.AreEqual("1111", result.LastDigits);
             Assert.AreEqual(card.ExpirationMonth, result.ExpirationMonth);
             Assert.AreEqual(card.ExpirationYear, result.ExpirationYear);
             Assert.AreEqual(card.Name, result.Name);
             Assert.AreEqual(Brand.Visa, result.Brand);
-            Assert.AreEqual("Bangkok", result.City);
-            Assert.AreEqual("Thailand", result.Country);
+            Assert.IsNull(result.City);
+            Assert.AreEqual("us", result.Country);
             Assert.AreEqual("123", result.Fingerprint);
-            Assert.AreEqual("123", result.Id);
-            Assert.AreEqual(new DateTime(2014, 10, 2, 6, 9, 1), result.CreatedAt);
+            Assert.AreEqual("card_test_123", result.Id);
+            Assert.AreEqual("/customers/cust_test_1/cards/card_test_123", result.Location);
+            Assert.AreEqual(new DateTime(2015, 1, 30, 7, 58, 52), result.CreatedAt);
         }
 
         [Test]

--- a/Omise.Net.NUnit.Test/CustomerTest.cs
+++ b/Omise.Net.NUnit.Test/CustomerTest.cs
@@ -431,6 +431,52 @@ namespace Omise.Net.NUnit.Test
         }
 
         [Test]
+        public void TestSetCustomerDefaultCard()
+        {
+            stubResponse(@"{
+								    'object': 'customer',
+								    'id': '123',
+								    'livemode': false,
+								    'location': '/customers/123',
+								    'default_card': 'card_test_123',
+								    'email': 'test11@localhost',
+								    'description': 'Test Customer',
+								    'created': '2014-10-02T08:12:12Z',
+								    'cards': {
+								        'object': 'list',
+								        'from': '1970-01-01T07:00:00+07:00',
+								        'to': '2014-10-02T15:31:35+07:00',
+								        'offset': 0,
+								        'limit': 20,
+								        'total': 1,
+								        'data': [
+											{
+											'object': 'card',
+										    'id': 'card_test_123',
+										    'livemode': false,
+										    'location': '/customers/123/cards/card_test_123',
+										    'country': 'us',
+										    'city': null,
+										    'postal_code': null,
+										    'financing': '',
+										    'last_digits': '4242',
+										    'brand': 'Visa',
+										    'expiration_month': 9,
+										    'expiration_year': 2017,
+										    'fingerprint': '123',
+										    'name': 'My Test Card',
+										    'created': '2014-10-02T05:25:10Z'
+											}
+										],
+								        'location': '/customers/123/cards'
+								    }
+								}");
+
+            var customer = client.CustomerService.UpdateDefaultCard("123", "card_test_123");
+            Assert.AreEqual("card_test_123", customer.DefaultCardId);
+        }
+
+        [Test]
         public void TestDeleteCustomer()
         {
             stubResponse(@"{

--- a/Omise.Net/Services/CardService.cs
+++ b/Omise.Net/Services/CardService.cs
@@ -74,9 +74,12 @@ namespace Omise
                 throw new ArgumentNullException("customerId");
             if (string.IsNullOrEmpty(cardToken))
                 throw new ArgumentNullException("cardToken");
-            string url = string.Format("/customers/{0}/cards", customerId);
-            string result = requester.ExecuteRequest(url, "POST", string.Format("card={0}", cardToken));
-            return cardFactory.Create(result);
+
+            var tokenInfo = tokenService.GetToken(cardToken);
+
+            string url = string.Format("/customers/{0}", customerId);
+            string result = requester.ExecuteRequest(url, "PATCH", string.Format("card={0}", cardToken));
+            return tokenInfo.Card;
         }
 
         /// <summary>

--- a/Omise.Net/Services/CardService.cs
+++ b/Omise.Net/Services/CardService.cs
@@ -52,14 +52,35 @@ namespace Omise
             if (!cardCreateInfo.Valid)
                 throw new InvalidCardException(getObjectErrors(cardCreateInfo));
 
-            var tokenResult = this.tokenService.CreateToken(new TokenInfo()
+            var tokenInfo = this.tokenService.CreateToken(new TokenInfo()
                 {
                     Card = cardCreateInfo
                 });
 
-            string url = string.Format("/customers/{0}/cards", customerId);
-            string result = requester.ExecuteRequest(url, "POST", string.Format("card={0}", tokenResult.Id));
-            return cardFactory.Create(result);
+            string url = string.Format("/customers/{0}", customerId);
+            string result = requester.ExecuteRequest(url, "PATCH", string.Format("card={0}", tokenInfo.Id));
+            var customer = customerFactory.Create(result);
+
+            //Verify that the card has been successfully added to the customer and return the card
+
+            Card foundCard = null;
+            foreach (var card in customer.CardCollection.Collection)
+            {
+                if (card.Id == tokenInfo.Card.Id)
+                {
+                    foundCard = card;
+                    break;
+                }
+            }
+
+            if (foundCard != null)
+            {
+                return foundCard;
+            }
+            else
+            {
+                throw new Exception("Unable to create a customer card. If problem persisted, please report to Omise.");
+            }
         }
 
         /// <summary>
@@ -79,7 +100,28 @@ namespace Omise
 
             string url = string.Format("/customers/{0}", customerId);
             string result = requester.ExecuteRequest(url, "PATCH", string.Format("card={0}", cardToken));
-            return tokenInfo.Card;
+            var customer = customerFactory.Create(result);
+
+            //Verify that the card has been successfully added to the customer and return the card
+
+            Card foundCard = null;
+            foreach (var card in customer.CardCollection.Collection)
+            {
+                if (card.Id == tokenInfo.Card.Id)
+                {
+                    foundCard = card;
+                    break;
+                }
+            }
+
+            if (foundCard != null)
+            {
+                return foundCard;
+            }
+            else
+            {
+                throw new Exception("Unable to create a customer card. If problem persisted, please report to Omise.");
+            }
         }
 
         /// <summary>

--- a/Omise.Net/Services/CustomerService.cs
+++ b/Omise.Net/Services/CustomerService.cs
@@ -115,7 +115,7 @@ namespace Omise
         }
 
         /// <summary>
-        /// Update the customer's default card.
+        /// Update the customer's default card. Set the customer's default card to specified card id
         /// </summary>
         /// <returns>Customer object</returns>
         /// <param name="customerId">Customer Id</param>

--- a/Omise.Net/Services/CustomerService.cs
+++ b/Omise.Net/Services/CustomerService.cs
@@ -113,6 +113,23 @@ namespace Omise
             string result = requester.ExecuteRequest("/customers/" + customerId, "DELETE", null);
             return customerFactory.Create(result);
         }
+
+        /// <summary>
+        /// Update the customer's default card.
+        /// </summary>
+        /// <returns>Customer object</returns>
+        /// <param name="customerId">Customer Id</param>
+        /// <param name="cardId">Card Id</param>
+        public Customer UpdateDefaultCard(string customerId, string cardId)
+        {
+            if (string.IsNullOrEmpty(customerId))
+                throw new ArgumentNullException("customerId");
+            if (string.IsNullOrEmpty(cardId))
+                throw new ArgumentNullException("cardId");
+
+            string result = requester.ExecuteRequest("/customers/" + customerId, "PATCH", string.Format("default_card={0}", cardId));
+            return customerFactory.Create(result);
+        }
     }
 }
 


### PR DESCRIPTION
Fix creating customer card to PATCH to the customer endpoint instead of POST to /customers/cust_xxxxxxxxxxx/cards, Add a service method to update customer's default card
