### PR TITLE
Clean up readme and remove token creation example

### DIFF
--- a/Omise.Net.sln
+++ b/Omise.Net.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		CHANGELOG.md = CHANGELOG.md
 		LICENSE.txt = LICENSE.txt
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ Determine if charge success
 In the charge result there is a bool property named 'Captured' which tells us that the money has been charged by the acquirer bank if the value is ```TRUE```, 
 otherwise there will be another factors making the charge not being captured. For more information, visit https://docs.omise.co/api/charges/
 
+Creating a customer
+-------------------
+```c#
+var customer = new CustomerInfo();
+customer.Email = "test@localhost";
+customer.Description = "My test customer";
+
+var customerResult = client.CustomerService.CreateCustomer(customer);
+``` 
+
+With the customerResult, you can get access to the customer properties such Id, Email, Description and so on.
+
 Transfer money to bank account
 ------------------------------
 ```c#

--- a/README.md
+++ b/README.md
@@ -21,39 +21,38 @@ The core of the library is the Client which contains all services to call the AP
   //public key is optional which is required only if you want to create a token on the server side
 ```
 
-Creating a first charge
------------------------
-Creating a charge requires a valid card token, you can create a card token with the card information.
-We recommended you to create a token using Omise.JS library which runs on browser side, the client will directly send the card information to Omise gateway so that your server doesn't have to deal with card information at all. However, the library also provides way to create a card token as below example (create a card token on server side requires PCI compliance on your system)
-
 Creating a token
 ----------------
+**Full Credit Card data should never touch or go through your servers. That means, Do not send the credit card data to Omise from your servers directly.**
 
-```c#
-var card = new CardCreateInfo ();
-card.Name="TestCard";
-card.Number="4242424242424242";
-card.ExpirationMonth = 9;
-card.ExpirationYear=2017;
-card.SecurityCode = "123";
+The token creation method in the library should only be used either with fake data in test mode (e.g.: quickly creating some fake data, testing our API from a terminal, etc.), or if you do and you are PCI-DSS compliant, sending card data from server requires a valid PCI-DSS certification.
+that said, you must achieve, maintain PCI ompliance at all times and do following a Security Best Practices https://www.pcisecuritystandards.org/documents/PCI_DSS_V3.0_Best_Practices_for_Maintaining_PCI_DSS_Compliance.pdf
 
-var token = new TokenInfo ();
-token.Card = card;
+Creating a token with Omise.js
+------------------------------
+We recommended you to create a token using [Omise.JS](https://github.com/omise/omise.js) library which runs on browser side. It uses javascript to send the credit card data on client side, send it to Omise, and then you can populate the form with a unique one-time used token which can be used later on.
 
-var tokenResult = client.TokenService.CreateToken(token);
-```
+Simplify the integration with Card.js
+-------------------------------------
+[Card.js](https://docs.omise.co/card-js/), by using it you can let it builds a credit card payment form window and creates a card token that you can use to create a charge with `omise-dotnet`.
 
-you can then use the tokenResult.Id to create a charge like below
+
+For both methods, the client will directly send the card information to Omise gateway, your servers don't have to deal with card information at all and you don't need to deal with credit card data hassle, it reduces risk.
+
+**Please read https://docs.omise.co/collecting-card-information/ regarding how to collecting card information.**
+
+Creating a charge
+-----------------
 
  ```c#
-var charge = new ChargeCreateInfo ();
-charge.Amount = 1000;
-charge.Currency = "THB";
-charge.Description = "Test charge";
-charge.Capture = true; //TRUE means auto capture the charge, FALSE means authorize only. Default is FALSE
-charge.CardId = tokenResult.Id;
-		
-var chargeResult = client.ChargeService.CreateCharge (charge);
+var chargeInfo = new ChargeCreateInfo ();
+chargeInfo.Amount = 10000; //Create a charge with amount 100 THB, here we are passing with the smallest currency unit which is 10000 satangs
+chargeInfo.Currency = "THB";
+chargeInfo.Description = "Test charge";
+chargeInfo.Capture = true; //TRUE means auto capture the charge, FALSE means authorize only. Default is FALSE
+chargeInfo.CardId = token; //Token generated with Omise.js or Card.js
+
+var charge = client.ChargeService.CreateCharge(chargeInfo);
  ```
 
 Determine if charge success
@@ -61,29 +60,5 @@ Determine if charge success
 
 In the charge result there is a bool property named 'Captured' which tells us that the money has been charged by the acquirer bank if the value is ```TRUE```, 
 otherwise there will be another factors making the charge not being captured. For more information, visit https://docs.omise.co/api/charges/
- 
-Getting a token
----------------
 
-```c#
-var tokenResult = client.TokenService.GetToken("tkn_xxxxxxxxxxxx");
-```
-
-Getting a charge
-----------------
-
-```c#
-var chargeResult = client.ChargeService.GetCharge("12345");
-```
-
-Creating a customer
--------------------
-```c#
-var customer = new CustomerInfo();
-customer.Email = "test@localhost";
-customer.Description = "My test customer";
-
-var customerResult = client.CustomerService.CreateCustomer(customer);
-``` 
-
-With the customerResult, you can get access to the customer properties such Id, Email, Description and so on.
+**Please read https://docs.omise.co/collecting-card-information/ for full developer api documentation.**


### PR DESCRIPTION
The PR mainly removes the example of how to create a token with Omise.Net library but recommend user to use Omise.js or Card.js instead.
