### PR TITLE
Rewrite how credentials and endpoints are handled.

### DIFF
--- a/Omise.Net/Backports.cs
+++ b/Omise.Net/Backports.cs
@@ -1,0 +1,6 @@
+﻿namespace Omise.Net
+{
+    // System.Func type is unavailable pre-net35
+    internal delegate TResult OFunc<T1, TResult>(T1 arg1);
+}
+

--- a/Omise.Net/Client.cs
+++ b/Omise.Net/Client.cs
@@ -2,8 +2,7 @@
 using System.Net;
 using System.IO;
 using System.Text;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using Omise.Net;
 
 namespace Omise
 {
@@ -12,8 +11,7 @@ namespace Omise
     /// </summary>
     public class Client
     {
-        private string secretKey;
-        private string publicKey;
+        private Credentials credentials;
         private IRequestManager requestManager;
 
         private ChargeService chargeService;
@@ -27,7 +25,7 @@ namespace Omise
             get
             {
                 if (chargeService == null)
-                    chargeService = new ChargeService(requestManager, secretKey, ApiVersion);
+                    chargeService = new ChargeService(requestManager, credentials, ApiVersion);
                 return chargeService;
             }
         }
@@ -43,7 +41,7 @@ namespace Omise
             get
             {
                 if (cardService == null)
-                    cardService = new CardService(requestManager, secretKey, this.TokenService, ApiVersion);
+                    cardService = new CardService(requestManager, credentials, this.TokenService, ApiVersion);
                 return cardService;
             }
         }
@@ -59,7 +57,7 @@ namespace Omise
             get
             {
                 if (customerService == null)
-                    customerService = new CustomerService(requestManager, secretKey, this.TokenService, ApiVersion);
+                    customerService = new CustomerService(requestManager, credentials, this.TokenService, ApiVersion);
                 return customerService;
             }
         }
@@ -75,7 +73,7 @@ namespace Omise
             get
             {
                 if (accountService == null)
-                    accountService = new AccountService(requestManager, secretKey, ApiVersion);
+                    accountService = new AccountService(requestManager, credentials, ApiVersion);
                 return accountService;
             }
         }
@@ -91,7 +89,7 @@ namespace Omise
             get
             {
                 if (tokenService == null)
-                    tokenService = new TokenService(requestManager, publicKey, ApiVersion);
+                    tokenService = new TokenService(requestManager, credentials, ApiVersion);
                 return tokenService;
             }
         }
@@ -107,7 +105,7 @@ namespace Omise
             get
             {
                 if (balanceService == null)
-                    balanceService = new BalanceService(requestManager, secretKey, ApiVersion);
+                    balanceService = new BalanceService(requestManager, credentials, ApiVersion);
                 return balanceService;
             }
         }
@@ -123,7 +121,7 @@ namespace Omise
             get
             {
                 if (transactionService == null)
-                    transactionService = new TransactionService(requestManager, secretKey, ApiVersion);
+                    transactionService = new TransactionService(requestManager, credentials, ApiVersion);
                 return transactionService;
             }
         }
@@ -139,7 +137,7 @@ namespace Omise
             get
             {
                 if (transferService == null)
-                    transferService = new TransferService(requestManager, secretKey, ApiVersion);
+                    transferService = new TransferService(requestManager, credentials, ApiVersion);
                 return transferService;
             }
         }
@@ -151,7 +149,7 @@ namespace Omise
             get
             { 
                 if (recipientService == null)
-                    recipientService = new RecipientService(requestManager, secretKey, ApiVersion);
+                    recipientService = new RecipientService(requestManager, credentials, ApiVersion);
                 return recipientService;
             }
         }
@@ -163,7 +161,7 @@ namespace Omise
             get
             {
                 if (disputeService == null)
-                    disputeService = new DisputeService(requestManager, secretKey, ApiVersion);
+                    disputeService = new DisputeService(requestManager, credentials, ApiVersion);
                 
                 return disputeService;
             }
@@ -177,7 +175,7 @@ namespace Omise
         /// <param name="secretKey">Secret key</param>
         public Client(string secretKey)
         {
-            this.secretKey = secretKey;
+            this.credentials = new Credentials(null, secretKey);
         }
 
         /// <summary>
@@ -186,8 +184,7 @@ namespace Omise
         /// <param name="secretKey">Secret key</param>
         public Client(string secretKey, string publicKey)
         {
-            this.secretKey = secretKey;
-            this.publicKey = publicKey;
+            this.credentials = new Credentials(publicKey, secretKey);
         }
 
         /// <summary>
@@ -198,7 +195,7 @@ namespace Omise
         public Client(IRequestManager requestManager, string secretKey)
         {
             this.requestManager = requestManager;
-            this.secretKey = secretKey;
+            this.credentials = new Credentials(null, secretKey);
         }
 
         /// <summary>
@@ -210,8 +207,7 @@ namespace Omise
         public Client(IRequestManager requestManager, string secretKey, string publicKey)
         {
             this.requestManager = requestManager;
-            this.secretKey = secretKey;
-            this.publicKey = publicKey;
+            this.credentials = new Credentials(publicKey, secretKey);
         }
     }
 }

--- a/Omise.Net/Credentials.cs
+++ b/Omise.Net/Credentials.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Text;
+
+namespace Omise.Net
+{
+    internal class Credentials
+    {
+        public Key PublicKey { get; private set; }
+        public Key SecretKey { get; private set; }
+
+        public Credentials(string pkey, string skey) {
+            if (string.IsNullOrEmpty(pkey) && string.IsNullOrEmpty(skey))
+                throw new ArgumentNullException("skey", "atleast one key must be provided.");
+                
+            PublicKey = pkey;
+            SecretKey = skey;
+        }
+
+        public string AuthorizationString() {
+            var authline = Encoding.GetEncoding("ISO-8859-1").GetBytes(PublicKey + ":");
+            return "Basic " + Convert.ToBase64String(authline);
+        }
+    }
+}
+

--- a/Omise.Net/Endpoint.cs
+++ b/Omise.Net/Endpoint.cs
@@ -1,0 +1,39 @@
+﻿namespace Omise.Net
+{
+    internal sealed partial class Endpoint
+    {
+        public static readonly Endpoint API = new Endpoint("https://api.omise.co", (creds) => creds.SecretKey);
+        public static readonly Endpoint Vault = new Endpoint("https://vault.omise.co", (creds) => creds.PublicKey);
+
+        public static Endpoint From(string value) {
+            switch (value)
+            {
+                case "https://api.omise.co":
+                    return API;
+                case "https://vault.omise.co":
+                    return Vault;
+            }
+
+            return null;
+        }
+    }
+
+    internal sealed partial class Endpoint
+    {
+        private readonly OFunc<Credentials, Key> keySelector;
+
+        public string Host { get; private set; }
+
+        private Endpoint(string host, OFunc<Credentials, Key> keySelector)
+        {
+            this.Host = host;
+            this.keySelector = keySelector;
+        }
+
+        public Key SelectKey(Credentials credentials)
+        {
+            return keySelector(credentials);
+        }
+    }
+}
+

--- a/Omise.Net/Key.cs
+++ b/Omise.Net/Key.cs
@@ -1,0 +1,43 @@
+﻿using System.Text;
+using Omise.Net;
+using System.Runtime.Remoting.Messaging;
+using System;
+
+namespace Omise.Net
+{
+    public struct Key
+    {
+        string key;
+
+        public bool IsTest { get { return key.Contains("_test_"); } }
+
+        public bool IsLive { get { return !IsTest; } }
+
+        private Key(string key)
+        {
+            this.key = key;
+        }
+
+        public string AuthorizationHeader()
+        {
+            var encoded = Encoding.GetEncoding("ISO-8859-1").GetBytes(key + ":");
+            return "Basic " + Convert.ToBase64String(encoded);
+        }
+
+        public override string ToString()
+        {
+            return key;
+        }
+
+        public static implicit operator string(Key k)
+        {
+            return k.ToString();
+        }
+
+        public static implicit operator Key(string str)
+        {
+            return new Key(str);
+        }
+    }
+}
+

--- a/Omise.Net/Omise.Net.csproj
+++ b/Omise.Net/Omise.Net.csproj
@@ -104,6 +104,10 @@
     <Compile Include="Enums\RecipientType.cs" />
     <Compile Include="Models\Refund.cs" />
     <Compile Include="Factories\RefundFactory.cs" />
+    <Compile Include="Credentials.cs" />
+    <Compile Include="Key.cs" />
+    <Compile Include="Endpoint.cs" />
+    <Compile Include="Backports.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Omise.Net/Services/AccountService.cs
+++ b/Omise.Net/Services/AccountService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Omise.Net;
 
 namespace Omise
 {
@@ -44,6 +45,11 @@ namespace Omise
         /// <param name="apiVersion">Api version</param>
         public AccountService(IRequestManager requestManager, string apiKey, string apiVersion)
             : base(requestManager, apiKey, apiVersion)
+        {
+        }
+
+        internal AccountService(IRequestManager requestManager, Credentials credentials, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
         {
         }
 

--- a/Omise.Net/Services/BalanceService.cs
+++ b/Omise.Net/Services/BalanceService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Omise.Net;
 
 namespace Omise
 {
@@ -44,6 +45,11 @@ namespace Omise
         /// <param name="apiVersion">Api version</param>
         public BalanceService(IRequestManager requestManager, string apiKey, string apiVersion)
             : base(requestManager, apiKey, apiVersion)
+        {
+        }
+
+        internal BalanceService(IRequestManager requestManager, Credentials credentials, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
         {
         }
 

--- a/Omise.Net/Services/CardService.cs
+++ b/Omise.Net/Services/CardService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using System.Text;
+using Omise.Net;
 
 namespace Omise
 {
@@ -63,6 +64,15 @@ namespace Omise
         {
             if (tokenService == null)
                 throw new ArgumentNullException("tokenService");
+            this.tokenService = tokenService;
+        }
+
+        internal CardService(IRequestManager requestManager, Credentials credentials, TokenService tokenService, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
+        {
+            if (tokenService == null)
+                throw new ArgumentNullException("tokenService");
+            
             this.tokenService = tokenService;
         }
 

--- a/Omise.Net/Services/ChargeService.cs
+++ b/Omise.Net/Services/ChargeService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Omise.Net;
 
 namespace Omise
 {
@@ -45,6 +46,11 @@ namespace Omise
         /// <param name="apiVersion">Api version</param>
         public ChargeService(IRequestManager requestManager, string apiKey, string apiVersion)
             : base(requestManager, apiKey, apiVersion)
+        {
+        }
+
+        internal ChargeService(IRequestManager requestManager, Credentials credentials, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
         {
         }
 

--- a/Omise.Net/Services/CustomerService.cs
+++ b/Omise.Net/Services/CustomerService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Omise.Net;
 
 namespace Omise
 {
@@ -89,6 +90,15 @@ namespace Omise
 
             string result = requester.ExecuteRequest("/customers", "POST", customerCreateInfo.ToRequestParams());
             return customerFactory.Create(result);
+        }
+
+        internal CustomerService(IRequestManager requestManager, Credentials credentials, TokenService tokenService, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
+        {
+            if (tokenService == null)
+                throw new ArgumentNullException("tokenService");
+
+            this.tokenService = tokenService;
         }
 
         /// <summary>

--- a/Omise.Net/Services/DisputeService.cs
+++ b/Omise.Net/Services/DisputeService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Omise.Net;
 
 namespace Omise
 {
@@ -46,6 +47,11 @@ namespace Omise
             : base(requestManager, apiKey, apiVersion)
         {
 
+        }
+
+        internal DisputeService(IRequestManager requestManager, Credentials credentials, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
+        {
         }
 
         public Dispute GetDispute(string disputeId){

--- a/Omise.Net/Services/RecipientService.cs
+++ b/Omise.Net/Services/RecipientService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using Omise.Net;
 
 namespace Omise
 {
@@ -45,6 +46,11 @@ namespace Omise
             : base(requestManager, apiKey, apiVersion)
         {
 
+        }
+
+        internal RecipientService(IRequestManager requestManager, Credentials credentials, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
+        {
         }
 
         public CollectionResponseObject<Recipient> GetAllRecipients() {

--- a/Omise.Net/Services/ServiceBase.cs
+++ b/Omise.Net/Services/ServiceBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Omise.Net;
 
 namespace Omise
 {
@@ -73,11 +74,12 @@ namespace Omise
         protected DisputeFactory disputeFactory;
 
         /// <summary>
-        /// The api base url for the service
+        /// The endpoint to use for the service.
         /// </summary>
-        protected virtual string ApiUrlBase
+        /// <value>The endpoint.</value>
+        internal virtual Endpoint Endpoint
         {
-            get { return "https://api.omise.co"; }
+            get { return Endpoint.API; }
         }
 
         private void init()
@@ -105,7 +107,7 @@ namespace Omise
         {
             if (requestManager == null)
             {
-                requester = new RequestManager(ApiUrlBase, apiKey);
+                requester = new RequestManager(Endpoint, new Credentials(null, apiKey), null);
             }
             else
             {
@@ -121,13 +123,13 @@ namespace Omise
         /// <param name="apiKey">Api key</param>
         public ServiceBase(string apiKey)
         {
-            requester = new RequestManager(ApiUrlBase, apiKey);
+            requester = new RequestManager(Endpoint, new Credentials(null, apiKey), null);
             init();
         }
 
         public ServiceBase(string apiKey, string apiVersion)
         {
-            requester = new RequestManager(ApiUrlBase, apiKey, apiVersion);
+            requester = new RequestManager(Endpoint, new Credentials(null, apiKey), apiVersion);
             init();
         }
 
@@ -135,7 +137,7 @@ namespace Omise
         {
             if (requestManager == null)
             {
-                requester = new RequestManager(ApiUrlBase, apiKey, apiVersion);
+                requester = new RequestManager(Endpoint, new Credentials(null, apiKey), apiVersion);
             }
             else
             {
@@ -143,6 +145,19 @@ namespace Omise
             }
 
             init();
+        }
+
+        internal ServiceBase(IRequestManager requestManager, Credentials credentials, string apiVersion)
+        {
+            if (credentials == null)
+                throw new ArgumentNullException("credentials");
+
+            if (requestManager == null)
+            {
+                requestManager = new RequestManager(Endpoint, credentials, apiVersion);
+            }
+
+            requester = requestManager;
         }
 
         /// <summary>

--- a/Omise.Net/Services/TokenService.cs
+++ b/Omise.Net/Services/TokenService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Omise.Net;
 
 namespace Omise
 {
@@ -7,14 +8,11 @@ namespace Omise
     /// </summary>
     public class TokenService : ServiceBase
     {
-        /// <summary>
-        /// Api base url
-        /// </summary>
-        protected override string ApiUrlBase
+        internal override Endpoint Endpoint
         {
             get
             {
-                return "https://vault.omise.co";
+                return Endpoint.Vault;
             }
         }
 
@@ -55,6 +53,11 @@ namespace Omise
         /// <param name="apiVersion">Api version</param>
         public TokenService(IRequestManager requestManager, string apiKey, string apiVersion)
             : base(requestManager, apiKey, apiVersion)
+        {
+        }
+
+        internal TokenService(IRequestManager requestManager, Credentials credentials, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
         {
         }
 

--- a/Omise.Net/Services/TransactionService.cs
+++ b/Omise.Net/Services/TransactionService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Omise.Net;
 
 namespace Omise
 {
@@ -43,6 +44,11 @@ namespace Omise
         /// <param name="apiKey">Api key</param>
         public TransactionService(IRequestManager requestManager, string apiKey, string apiVersion)
             : base(requestManager, apiKey, apiVersion)
+        {
+        }
+
+        internal TransactionService(IRequestManager requestManager, Credentials credentials, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
         {
         }
 

--- a/Omise.Net/Services/TransferService.cs
+++ b/Omise.Net/Services/TransferService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Omise.Net;
 
 namespace Omise
 {
@@ -46,6 +47,11 @@ namespace Omise
         /// <param name="apiVersion">Api version</param>
         public TransferService(IRequestManager requestManager, string apiKey, string apiVersion)
             : base(requestManager, apiKey, apiVersion)
+        {
+        }
+
+        internal TransferService(IRequestManager requestManager, Credentials credentials, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
         {
         }
 

--- a/Omise.Net/Services/UserService.cs
+++ b/Omise.Net/Services/UserService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Omise.Net;
 
 namespace Omise
 {
@@ -23,6 +24,11 @@ namespace Omise
         /// <param name="apiKey">Api key</param>
         public UserService(IRequestManager requestManager, string apiKey)
             : base(requestManager, apiKey)
+        {
+        }
+
+        internal UserService(IRequestManager requestManager, Credentials credentials, string apiVersion)
+            : base(requestManager, credentials, apiVersion)
         {
         }
     }


### PR DESCRIPTION
**1. Objective reason**

Refactor to enable `RequestManager` to select keys based on the endpoint it is sending to, fixing `TokenService` in the process.

**2. Description of change**

Introduced a few new types:
- `Key` - struct implicitly convertible to string to encapsulate key logic.
- `Credentials` - class to hold both secret key and public key.
- `Endpoint` - contains the host information and knows which keys to use from the `Credentials`.

And refactored `RequestManager`, `Client` and everything else to use these new types.

**3. Developers affected by the change**

@tommy-omise 

**4. Impact of the change**

None.

All new API are marked `internal` and all `public`API are left untouched.

**5. Priority of change**

Normal

**6. Alternate solution (if any)**

None.
