### PR TITLE
Add expired to charge status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+# v2.7.2
+
+* Add expired in charge status.
+
 # v2.7.1
 
 * Update nuget packages.

--- a/Omise/Models/ChargeStatus.cs
+++ b/Omise/Models/ChargeStatus.cs
@@ -3,6 +3,7 @@
     public enum ChargeStatus
     {
         Failed,
+        Expired,
         Pending,
         Successful,
         Reversed


### PR DESCRIPTION
From Phabricator [T7516] missing `expired` in ChargeStatus