### PR TITLE
Fix bug for nuget packaging + netstandard 2.0 produces large package

### DIFF
--- a/Omise/Omise.csproj
+++ b/Omise/Omise.csproj
@@ -15,7 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
When trying to build nuget package in netstandard 2.0. The total package size is much bigger (~1.9MB) than the previous version (~44KB).

After some investigation . The package `NuGet.Build.Packaging` causes the total package size to increase because it includes all `System*.dll`.

Just remove it and rebuild again will fix.
