### PR TITLE
Use dotnet v3.1.x for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,12 @@ jobs:
   release:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet: [ '2.1.x', '3.1.x', '5.0.x' ]
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: ${{ matrix.dotnet }}
+        dotnet-version: '3.1.x'
 
     - name: Install dependencies
       run: nuget restore Omise.sln


### PR DESCRIPTION
`--skip-duplicate` requires dotnet `v3.1.x`.