### PR TITLE
Add wechat_pay source

### DIFF
--- a/Omise.Examples/Example.cs
+++ b/Omise.Examples/Example.cs
@@ -65,7 +65,7 @@ namespace Omise.Examples
             });
         }
 
-        // Creates a new PaymentSource called RetrieveSourceRabbitLinepay, as sources can be created client-side (as well as server-side).
+        // Creates a new PaymentSource called RetrieveSourceWeChatPay, as sources can be created client-side (as well as server-side).
         protected async Task<PaymentSource> RetrieveSourceWeChatPay()
         {
             return await Client.Sources.Create(new CreatePaymentSourceRequest

--- a/Omise.Examples/Example.cs
+++ b/Omise.Examples/Example.cs
@@ -65,6 +65,19 @@ namespace Omise.Examples
             });
         }
 
+        // Creates a new PaymentSource called RetrieveSourceRabbitLinepay, as sources can be created client-side (as well as server-side).
+        protected async Task<PaymentSource> RetrieveSourceWeChatPay()
+        {
+            return await Client.Sources.Create(new CreatePaymentSourceRequest
+            {
+                Amount = 2000,
+                Currency = "thb",
+                Ip = "127.0.0.1",
+                Type = OffsiteTypes.WeChatPay,
+                Flow = FlowTypes.Redirect
+            });
+        }
+
         public async Task<PaymentSource> RetrieveSourceTrueMoney()
         {
             return await Client.Sources.Create(new CreatePaymentSourceRequest

--- a/Omise.Examples/Examples/Charges.cs
+++ b/Omise.Examples/Examples/Charges.cs
@@ -209,6 +209,25 @@ namespace Omise.Examples
             Console.WriteLine($"created charge: {charge.Id}");
             Console.WriteLine($"Redirect customer to: {charge.AuthorizeURI}");
         }
+
+        #region WeChat Pay
+        public async Task Create__Create_With_Source_WeChatPay()
+        {
+            var source = await RetrieveSourceWeChatPay();
+            var charge = await Client.Charges.Create(new CreateChargeRequest()
+            {
+                Amount = 2000,
+                Currency = "thb",
+                Offsite = OffsiteTypes.WeChatPay,
+                Flow = FlowTypes.Redirect,
+                Source = source
+            });
+
+            Console.WriteLine($"created charge: {charge.Id}");
+            Console.WriteLine($"Redirect customer to: {charge.AuthorizeURI}");
+        }
+        #endregion
+
         #endregion
 
         #region Wallet Alipay

--- a/Omise.Examples/Examples/PaymentSources.cs
+++ b/Omise.Examples/Examples/PaymentSources.cs
@@ -84,7 +84,7 @@ namespace Omise.Examples
 
         protected string RetrieveWeChatPaySourceId()
         {
-            return RetrieveSourceRabbitLinepay().Result.Id;
+            return RetrieveSourceWeChatPay().Result.Id;
         }
         #endregion
 

--- a/Omise.Examples/Examples/PaymentSources.cs
+++ b/Omise.Examples/Examples/PaymentSources.cs
@@ -60,6 +60,34 @@ namespace Omise.Examples
         }
         #endregion
 
+        #region WeChat Pay
+        public async Task Create__Create_WeChatPay()
+        {
+            var source = await Client.Sources.Create(new CreatePaymentSourceRequest
+            {
+                Amount = 2000,
+                Currency = "thb",
+                Ip = "127.0.0.1",
+                Type = OffsiteTypes.WeChatPay,
+                Flow = FlowTypes.Redirect
+            });
+
+            Console.WriteLine($"created source: {source.Id}");
+        }
+
+        public async Task Retrieve__Retrieve_WeChatPay()
+        {
+            var sourceId = RetrieveWeChatPaySourceId();
+            var source = await Client.Sources.Get(sourceId);
+            Console.WriteLine($"source flow is {source.Flow.ToString()}");
+        }
+
+        protected string RetrieveWeChatPaySourceId()
+        {
+            return RetrieveSourceRabbitLinepay().Result.Id;
+        }
+        #endregion
+
         #region BillPayment
         public async Task Create__Create_BillPayment()
         {

--- a/Omise/Models/Models.cs
+++ b/Omise/Models/Models.cs
@@ -964,6 +964,8 @@ namespace Omise.Models {
         public string StoreName { get; set; }
         [JsonProperty("terminal_id")]
         public string TerminalId { get; set; }
+        [JsonProperty("ip")]
+        public string Ip { get; set; }
 
         public override bool Equals(object obj) {
             if (obj == null) return false;
@@ -985,6 +987,7 @@ namespace Omise.Models {
                 object.Equals(this.StoreId, another.StoreId) &&
                 object.Equals(this.StoreName, another.StoreName) &&
                 object.Equals(this.TerminalId, another.TerminalId) &&
+                object.Equals(this.Ip, another.Ip) &&
                 true;
         }
 
@@ -1032,6 +1035,9 @@ namespace Omise.Models {
                 }
                 if (TerminalId != default(string)) {
                     hash = hash * 23 + TerminalId.GetHashCode();
+                }
+                if (Ip != default(string)) {
+                    hash = hash * 23 + Ip.GetHashCode();
                 }
 
                 return hash;

--- a/Omise/Models/OffsiteTypes.cs
+++ b/Omise/Models/OffsiteTypes.cs
@@ -46,6 +46,8 @@ namespace Omise.Models
         MobileBankingOCBCPAO,
         [EnumMember(Value = "rabbit_linepay")]
         RabbitLinepay,
+        [EnumMember(Value = "wechat_pay")]
+        WeChatPay,
         [EnumMember(Value = "paynow")]
         Paynow,
         [EnumMember(Value = "points_citi")]

--- a/Omise/Models/PaymentSourceRequest.cs
+++ b/Omise/Models/PaymentSourceRequest.cs
@@ -16,5 +16,6 @@ namespace Omise.Models
 
         [JsonProperty("phone_number")]
         public string PhoneNumber { get; set; }
+        public string Ip { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ credit card data through your server directly. **Please read our [Security Best
 Practices](https://www.omise.co/security-best-practices) guideline before deploying
 production code using this package.**
 
-**Note:** It is important to mention that when creating a `wechat_pay` source it is advised to pass the `ip` param. This `ip` param should be the client's ip and not the server's ip.
+**Note:** It is important to mention that when creating a `wechat_pay` source, it is advised to pass the `ip` parameter. This `ip` parameter should be the ip from the customer's device and not the server's ip.
 
 ### Creating a Charge with a Token
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ credit card data through your server directly. **Please read our [Security Best
 Practices](https://www.omise.co/security-best-practices) guideline before deploying
 production code using this package.**
 
+**Note:** It is important to mention that when creating a `wechat_pay` source it is advised to pass the `ip` param. This `ip` param should be the client's ip and not the server's ip.
+
 ### Creating a Charge with a Token
 
 ```c#


### PR DESCRIPTION
## Description

Add `wechat_pay` source. More info could be found [here](https://docs.opn.ooo/wechat-pay-online)

*NOTE:*

* It is important to mention that when creating a `wechat_pay` source, it is advised to pass the `ip` parameter. This `ip` parameter should be the ip from the customer's device and not the server's ip.