### PR TITLE
Drop support for 2.x .NET to enable usage of c# 8.0

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Install dependencies
       run: nuget restore Omise.sln
     - name: Test
-      run: make test
+      run: dotnet test

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       matrix:
         dotnet: ["3.0", "5.0", "6.0", "7.0", "8.0"]
+    env:
+      TargetDotNet: ${{ matrix.dotnet }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: [ '2.1.x', '3.1.x', '5.0.x' ]
+        dotnet: ["3.0", "5.0", "6.0", "7.0", "8.0"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Install dependencies

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       matrix:
         dotnet: ["3.0", "5.0", "6.0", "7.0", "8.0"]
-    env:
-      TargetDotNet: ${{ matrix.dotnet }}
+
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
@@ -24,4 +23,4 @@ jobs:
     - name: Install dependencies
       run: nuget restore Omise.sln
     - name: Test
-      run: dotnet test
+      run: make test TargetDotNet=${{ matrix.dotnet }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '3.1.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       run: nuget restore Omise.sln
 
     - name: Test
-      run: make test
+      run: dotnet test
 
     - name: Create package
       run: dotnet pack -c Release Omise/Omise.csproj

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       run: nuget restore Omise.sln
 
     - name: Test
-      run: dotnet test
+      run: make test TargetDotNet=3.0
 
     - name: Create package
       run: dotnet pack -c Release Omise/Omise.csproj

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make
 
 CONFIG   := Debug
-PLATFORM := netstandard2.0
+PLATFORM := netstandard2.1
 
 OMISE_CSPROJ      := Omise/Omise.csproj
 OMISE_TEST_CSPROJ := Omise.Tests/Omise.Tests.csproj
@@ -14,11 +14,14 @@ T4_FILES        := $(wildcard Omise/**/*.tt Omise/*.tt Omise.Tests/**/*.tt Omise
 T4_OUTPUT_FILES := $(T4_FILES:.tt=.cs)
 
 MONO    := mono
-MSBUILD := msbuild /p:Configuration=$(CONFIG)
+MSBUILD := dotnet build /p:Configuration=$(CONFIG)
 NUNIT := dotnet test
 T4      := $(MONO) /Applications/Visual\ Studio.app/Contents/Resources/lib/monodevelop/AddIns/MonoDevelop.TextTemplating/TextTransform.exe
 
 .PHONY: test clean
+
+DOTNETEXPORT:
+    export TargetDotNet=$(TargetDotNet)
 
 default: build
 
@@ -30,7 +33,7 @@ build: $(OMISE_DLL)
 $(OMISE_DLL): $(OMISE_CSPROJ) $(SRC_FILES) $(T4_OUTPUT_FILES)
 	$(MSBUILD) /target:Build;Pack $(OMISE_CSPROJ)
 
-build-test: $(OMISE_TEST_DLL) $(SRC_TEST_FILES)
+build-test: $(DOTNETEXPORT) $(OMISE_TEST_DLL) $(SRC_TEST_FILES)
 $(OMISE_TEST_DLL): $(OMISE_TEST_CSPROJ) $(SRC_TEST_FILES) $(T4_OUTPUT_FILES)
 	$(MSBUILD) $(OMISE_TEST_CSPROJ)
 

--- a/Omise.Examples/Omise.Examples.csproj
+++ b/Omise.Examples/Omise.Examples.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Omise.Examples</RootNamespace>
 
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Omise.Examples/Omise.Examples.csproj
+++ b/Omise.Examples/Omise.Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Omise.Examples</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/Omise.Tests/Omise.Tests.csproj
+++ b/Omise.Tests/Omise.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Omise.Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/Omise.Tests/Omise.Tests.csproj
+++ b/Omise.Tests/Omise.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Omise.Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/Omise.Tests/Omise.Tests.csproj
+++ b/Omise.Tests/Omise.Tests.csproj
@@ -1,11 +1,50 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Default target framework -->
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Omise.Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <!-- Define conditions for each .NET SDK version -->
+  <Choose>
+    <!-- .NET Core 3.0 -->
+    <When Condition="'$(TargetDotNet)' == '3.0'">
+      <PropertyGroup>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+      </PropertyGroup>
+    </When>
+
+    <!-- .NET 5.0 -->
+    <When Condition="'$(TargetDotNet)' == '5.0'">
+      <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+      </PropertyGroup>
+    </When>
+
+    <!-- .NET 6.0 -->
+    <When Condition="'$(TargetDotNet)' == '6.0'">
+      <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+      </PropertyGroup>
+    </When>
+
+    <!-- .NET 7.0 -->
+    <When Condition="'$(TargetDotNet)' == '7.0'">
+      <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+      </PropertyGroup>
+    </When>
+
+    <!-- .NET 8.0 -->
+    <When Condition="'$(TargetDotNet)' == '8.0'">
+      <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+      </PropertyGroup>
+    </When>
+  </Choose>
 
   <ItemGroup>
     <!-- 

--- a/Omise/Omise.csproj
+++ b/Omise/Omise.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Omise</PackageId>
     <PackageVersion>2.13.0</PackageVersion>
     <Authors>Omise &lt;support@omise.co&gt;</Authors>


### PR DESCRIPTION
## Description

In order to support new features introduced in `c# 8.0` the support for `.NET 2.x` has been dropped as the minimum .NET version that supports `c# 8.0` is `.NET 3.0` with a target framework of `netstandard2.1`