### PR TITLE
Add nullable enum serialization condition

### DIFF
--- a/Omise.Tests/RealNetworkTest.cs
+++ b/Omise.Tests/RealNetworkTest.cs
@@ -68,6 +68,7 @@ namespace Omise.Tests.ManualTesting
                 Barcode = "Barcode",
                 Billing = new Billing() { City = "City", Country = "TH", PostalCode = "18321", State = "State", Street1 = "Streets1", Street2 = "Street2" },
                 Currency = "THB",
+                PlatformType = PlatformTypes.Web,
                 Email = "test@gmail.com",
                 Flow = FlowTypes.Redirect,
                 Ip = "10.0.0.2",

--- a/Omise.Tests/SerializerTest.cs
+++ b/Omise.Tests/SerializerTest.cs
@@ -14,13 +14,13 @@ namespace Omise.Tests
         const string DummyJson =
             @"{""james"":""Howlett"",""scott"":""Summers"",""johny"":""Mnemonic""," +
             @"""with"":""SPACES SPACES"",""created_at"":""9999-12-31T23:59:59.9999999""," +
-            @"""checked"":true,""enumer"":""twth"",""enumer2"":""once"",""nullEnum"":null," +
+            @"""checked"":true,""enumer"":""twth"",""enumer2"":""once"",""nullEnum"":null,""nullableEnum"":""once""," +
             @"""nested"":{""field"":""inner""," +
             @"""filters"":{""dictionary"":""should works""}}}";
         const string DummyUrlEncoded =
             "james=Howlett&scott=Summers&Johny=Mnemonic&" +
             "with=SPACES+SPACES&created_at=9999-12-31T23%3A59%3A59Z&" +
-            "checked=true&enumer=twth&enumer2=once&" +
+            "checked=true&enumer=twth&enumer2=once&nullableenum=once&" +
             "nested%5Bfield%5D=inner&nested%5Bfilters%5D%5Bdictionary%5D=should+works";
 
         Serializer Serializer { get; set; }
@@ -42,7 +42,6 @@ namespace Omise.Tests
                 Serializer.JsonSerialize(stream, Dummy);
                 result = stream.ToDecodedString();
             }
-
             Assert.AreEqual(DummyJson, result);
         }
 
@@ -60,6 +59,7 @@ namespace Omise.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(Dummy.James, result.James);
             Assert.AreEqual(Dummy.Scott, result.Scott);
+            Assert.AreEqual(Dummy.NullableEnum, result.NullableEnum);
         }
 
         [Test]
@@ -68,6 +68,7 @@ namespace Omise.Tests
             Serializer.JsonPopulate(DummyJson, Dummy);
             Assert.AreEqual("Howlett", Dummy.James);
             Assert.AreEqual("Summers", Dummy.Scott);
+            Assert.AreEqual("Once", Dummy.NullableEnum.ToString());
         }
 
         [Test]
@@ -95,6 +96,7 @@ namespace Omise.Tests
         public DummyEnum Enumer { get; set; }
         public DummyEnum Enumer2 { get; set; }
         public DummyEnum NullEnum { get; set; }
+        public DummyEnum? NullableEnum { get; set; }
         public NestedKlass Nested { get; set; }
 
         public enum DummyEnum
@@ -123,6 +125,7 @@ namespace Omise.Tests
             FieldIsNull = null;
             Enumer = DummyEnum.TwiceThrice;
             Enumer2 = DummyEnum.Once;
+            NullableEnum = DummyEnum.Once;
             NullEnum = DummyEnum.None;
             Nested = new NestedKlass
             {

--- a/Omise/EnumValueConverter.cs
+++ b/Omise/EnumValueConverter.cs
@@ -30,7 +30,8 @@ namespace Omise
 
         public override bool CanConvert(Type objectType)
         {
-            return objectType.GetTypeInfo().IsEnum;
+            // Check if the object type is an enum or a nullable enum
+            return objectType.GetTypeInfo().IsEnum || (Nullable.GetUnderlyingType(objectType)?.IsEnum == true);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)


### PR DESCRIPTION
## Description
The serialization code was not handling nullable enums properly as it was skipped from the serialization. The new code adds a condition to include it in the serialization process.