### PR TITLE
Fix version reporting that defaulted to 1.0.0.0 due to absent version…

### DIFF
--- a/Omise.Tests/RequesterTest.cs
+++ b/Omise.Tests/RequesterTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using Omise.Models;
 using Omise.Tests.Util;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Omise.Tests
 {
@@ -32,14 +34,20 @@ namespace Omise.Tests
                 Assert.That(authHeader, Is.EqualTo(expectedAuthHeader));
 
                 var libAsm = typeof(Requester).Assembly;
-                var clrAsm = typeof(object).Assembly;
+                var libVersion = libAsm
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                    .InformationalVersion ?? libAsm.GetName().Version.ToString();
 
-                var libVersion = libAsm.GetName().Version.ToString();
-                var clrVersion = clrAsm.GetName().Version.ToString();
+                if (libVersion.Contains("+"))
+                {
+                    libVersion = libVersion.Substring(0, libVersion.IndexOf("+"));
+                }
 
                 var userAgents = req.Headers.GetValues("User-Agent").ToList();
-                Assert.That(userAgents, Contains.Item($"Omise.Net/{libVersion}"));
-                Assert.That(userAgents, Contains.Item($".Net/{clrVersion}"));
+                var uaString = string.Join(" ", userAgents);
+                
+                Assert.That(uaString, Does.Contain($"Omise.Net/{libVersion}"));
+                Assert.That(uaString, Does.Contain($".Net/{RuntimeInformation.FrameworkDescription}"));
 
                 var apiVersion = req.Headers.GetValues("Omise-Version").FirstOrDefault();
                 Assert.That(apiVersion, Is.EqualTo("2000-02-01"));

--- a/Omise/Omise.csproj
+++ b/Omise/Omise.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Omise</PackageId>
-    <PackageVersion>4.3.0</PackageVersion>
+    <Version>4.3.0</Version>
     <Authors>Omise &lt;support@omise.co&gt;</Authors>
     <PackageIconUrl>https://cdn.omise.co/assets/frontend-images/omise-logo.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/omise/omise-dotnet/blob/master/LICENSE</PackageLicenseUrl>

--- a/Omise/Requester.cs
+++ b/Omise/Requester.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Omise.Models;
 using System.IO;
 using System.Text;
+using System.Runtime.InteropServices;
 
 namespace Omise
 {
@@ -45,13 +46,21 @@ namespace Omise
 
         IDictionary<string, string> buildRequestMetadata()
         {
-            var thisAsmName = GetType().GetTypeInfo().Assembly.GetName();
-            var clrAsmName = typeof(object).GetTypeInfo().Assembly.GetName();
+            var libAsm = typeof(Requester).Assembly;
+            var libVersion = libAsm
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion ?? libAsm.GetName().Version.ToString();
+
+            // Some pipelines might use the commit hash in the version which is typical in dotnet builds but we do not want to include that in the user agent
+            if (libVersion.Contains("+"))
+            {
+                libVersion = libVersion.Substring(0, libVersion.IndexOf("+"));
+            }
 
             return new Dictionary<string, string>
             {
-                { "Omise.Net", thisAsmName.Version.ToString() },
-                { ".Net", clrAsmName.Version.ToString() },
+                { "Omise.Net", libVersion },
+                { ".Net", RuntimeInformation.FrameworkDescription },
             };
         }
 


### PR DESCRIPTION
## Description

Fix version reporting in the created user agent. The original version defaulted to 1.0.0.0 or similar numbers due to missing `Version` property in the `.csproj` file.